### PR TITLE
Add testing for main, fix formatting/readability

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ from src.config import load_env_vars
 
 env_vars = load_env_vars()
 
+
 def main():
     # number of pages of movies to get from the API. 1 page is 20 movies.
     pages = 1
@@ -10,15 +11,18 @@ def main():
     # api authorization
     headers = {
         "accept": "application/json",
-        "Authorization": "Bearer " + env_vars["TMDB_API_TOKEN"]
+        "Authorization": "Bearer " + env_vars["TMDB_API_TOKEN"],
     }
 
-    data = toprated_movies(pages, headers) # gets movie data from the TMDB API
-    data = extract_movie_data(data) # removes any animated movies from the list and any unnecessary data
-    data = actors(data, headers) # adds the top actors to the json
-    data = actor_images(data, headers) # adds the top actors images to the json
-    data = related_movies(data, headers) # find any related movies that could be alternative answers
-
+    data = toprated_movies(pages, headers)  # gets movie data from the TMDB API
+    data = extract_movie_data(
+        data
+    )  # removes any animated movies from the list and any unnecessary data
+    data = actors(data, headers)  # adds the top actors to the json
+    data = actor_images(data, headers)  # adds the top actors images to the json
+    data = related_movies(
+        data, headers
+    )  # find any related movies that could be alternative answers
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,7 @@ def main():
 
     # api authorization
     headers = {
-        "accept": "application/json",
+        "Accept": "application/json",
         "Authorization": "Bearer " + env_vars["TMDB_API_TOKEN"],
     }
 
@@ -18,9 +18,9 @@ def main():
     data = extract_movie_data(
         data
     )  # removes any animated movies from the list and any unnecessary data
-    data = actors(data, headers)  # adds the top actors to the json
-    data = actor_images(data, headers)  # adds the top actors images to the json
-    data = related_movies(
+    actors(data, headers)  # adds the top actors to the json
+    actor_images(data, headers)  # adds the top actors images to the json
+    related_movies(
         data, headers
     )  # find any related movies that could be alternative answers
 

--- a/src/movies.py
+++ b/src/movies.py
@@ -1,47 +1,63 @@
 import requests
 import json
 
-# standard URL for the TMDB API
-TMDB_BASE_URL = "https://api.themoviedb.org/3/"
-# number of actors that will be used in the game (this will remain at 4)
+# TMDB API endpoints.
+TMDB_BASE_URL = "https://api.themoviedb.org/3"
+TMDB_POPULAR_URI = "/movie/popular"
+TMDB_TOP_RATED_URI = "/movie/top_rated"
+TMDB_MOVIE_ACTORS_URI_FMT = "/movie/{}/credits"
+TMDB_ACTOR_IMAGES_URI_FMT = "/person/{}/images"
+TMDB_ACTOR_CREDITS_URI_FMT = "/person/{}/movie_credits"
+
+CONTENT_LANGUAGE = "en-US"
 NUMBER_OF_ACTORS = 4
+TMDB_REGION_CODE_USA = (
+    840  # See https://en.wikipedia.org/wiki/ISO_3166-1 for other country codes.
+)
+TMDB_GENRE_ANIMATION = 16
 
 
 def popular_movies(pages, headers):
     """
-    This function calls the TMDB API for the popular movies list
+    Calls the TMDB API for the popular movies list
 
-    :param pages: int - number of pages of top rated movies to get there are 20 results on each page
+    :param pages: int - number of pages of top rated movies to get (there are 20 results on each page)
     :param headers: dict - api authorization header
-    :return: dict return the api response of popular movies
+    :return: dict - the api response of popular movies
     """
 
     # api endpoint
-    url = "{}movie/popular?language=en-US&page={}&region=840".format(
-        TMDB_BASE_URL, pages
-    )  # region 840 is USA see https://en.wikipedia.org/wiki/ISO_3166-1 for other country codes
+    url = "{}{}".format(TMDB_BASE_URL, TMDB_POPULAR_URI)
+    params = {
+        "language": CONTENT_LANGUAGE,
+        "page": pages,
+        "region": TMDB_REGION_CODE_USA,
+    }
 
     # use the api url and headers to get the information on the popular movies
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, params=params, headers=headers)
     return response.json()
 
 
 def toprated_movies(pages, headers):
     """
-    This function calls the TMDB API for the top rated movies list
+    Calls the TMDB API for the top rated movies list
 
-    :param pages: int - number of pages of top rated movies to get there are 20 results on each page
+    :param pages: int - number of pages of top rated movies to get (20 per page)
     :param headers: dict - api authorization header
-    :return: dict return the api response of top rated movies
+    :return: dict - the api response of top rated movies
     """
 
     # api endpoint
-    url = "{}movie/top_rated?language=en-US&page={}&region=840".format(
-        TMDB_BASE_URL, pages
-    )
+    url = "{}{}".format(TMDB_BASE_URL, TMDB_TOP_RATED_URI)
+    params = {
+        "language": CONTENT_LANGUAGE,
+        "page": pages,
+        "region": TMDB_REGION_CODE_USA,
+    }
 
     # use the api url and headers to get the information on the popular movies
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, params=params, headers=headers)
     return response.json()
 
 
@@ -49,70 +65,79 @@ def extract_movie_data(movies):
     """
     Take the movie id and title out of the API results
 
-    :param movies: dict - a dict of movie data
-    :return: dict return only the extracted data from the movies should be just the ids and the title
+    :param movies: dict - movie data
+    :return: dict - the extracted data for each movie
     """
 
     # extract ID and Title
-    extracted_data = [
-        {"id": movie.get("id"), "title": movie.get("title")}
-        for movie in movies.get("results", [])
-        if 16
-        not in movie.get(
-            "genre_ids", []
-        )  # genre 16 is animation we are choosing to ignore it for now since it will be difficult to recognize actors
-    ]
+    extracted_data = []
+    for movie in movies.get("results", []):
+        movie_id = movie.get("id")
+        title = movie.get("title")
+        genre_ids = movie.get("genre_ids", [])
+
+        # We are choosing to ignore animation for now since it will be difficult to recognize actors.
+        if TMDB_GENRE_ANIMATION not in genre_ids:
+            extracted_data.append(
+                {
+                    "id": movie_id,
+                    "title": title,
+                }
+            )
+
     return {"movies": extracted_data}
 
 
 def actors(movies, headers):
     """
-    This function gets the actors from a given movie and then calls the popular_actors function to get the most popular ones
+    Gets the actors from a given movie and then adds the most popular ones to the movie data.
 
-    :param movies: dict - a dict of movie data
+    :param movies: dict - movie data
     :param headers: dict - api authorization header
-    :return: dict return the movies dict after adding the most popular actors to each movie
     """
 
     # run an api call on each movie and get the cast, after that call popular_actors to get the most popular actors and add them to the json
     for movie in movies.get("movies", []):
         movie_id = movie.get("id")
+
         # api endpoint
-        url = "{}movie/{}/credits?language=en-US".format(TMDB_BASE_URL, movie_id)
+        movie_actors_uri = TMDB_MOVIE_ACTORS_URI_FMT.format(movie_id)
+        url = "{}{}".format(TMDB_BASE_URL, movie_actors_uri)
+        params = {"language": CONTENT_LANGUAGE}
+
         # use the api url and headers to get the cast
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, params=params, headers=headers)
         most_popular_actors = popular_actors(response.json())
 
         # Update the existing movie data with actor ids
         movie["actors"] = most_popular_actors
 
-    return movies
-
 
 def popular_actors(cast):
     """
-    This is a helper function that gets the most popular actors from a given movie cast.
+    Gets the most popular actors from a given movie cast.
 
-    :param cast: dict - the cast of a certain movie as well as data on the actors one entry looks like this
-    "cast": [
-        {
-        "adult": false,
-        "gender": 2,
-        "id": 504,
-        "known_for_department": "Acting",
-        "name": "Tim Robbins",
-        "original_name": "Tim Robbins",
-        "popularity": 32.809,
-        "profile_path": "/A4fHNLX73EQs78f2G6ObfKZnvp4.jpg",
-        "cast_id": 3,
-        "character": "Andy Dufresne",
-        "credit_id": "52fe4231c3a36847f800b131",
-        "order": 0
-        }
-    ]
+    :param cast: dict - data on the actors in a movie, each entry in the format:
+        "cast": [
+            {
+            "adult": false,
+            "gender": 2,
+            "id": 504,
+            "known_for_department": "Acting",
+            "name": "Tim Robbins",
+            "original_name": "Tim Robbins",
+            "popularity": 32.809,
+            "profile_path": "/A4fHNLX73EQs78f2G6ObfKZnvp4.jpg",
+            "cast_id": 3,
+            "character": "Andy Dufresne",
+            "credit_id": "52fe4231c3a36847f800b131",
+            "order": 0
+            }
+        ]
 
-    :return: dict - return the ids of the most popular actors
+    :return: dict - the ids of the most popular actors
     """
+
     # sort the cast list based on popularity in descending order
     sorted_cast = sorted(cast["cast"], key=lambda x: x["popularity"], reverse=True)
 
@@ -123,49 +148,46 @@ def popular_actors(cast):
 
 def actor_images(movies, headers):
     """
-    This function gets the actors images from the api
+    Gets the actors images from the api
 
-    :param movies: dict - a dict of movie data
+    :param movies: dict - movie data
     :param headers: dict - api authorization header
-    :return: dict the updated movies dict with pictures of the actors
     """
-    actor_url = []
+    actor_urls = []
 
     for movie in movies.get("movies", []):
         actor_ids = movie.get("actors", [])
         for actor_id in actor_ids:
 
             # api endpoint for getting actor images
-            url = "{}person/{}/images".format(TMDB_BASE_URL, actor_id)
+            actor_images_uri = TMDB_ACTOR_IMAGES_URI_FMT.format(actor_id)
+            url = "{}{}".format(TMDB_BASE_URL, actor_images_uri)
             response = requests.get(url, headers=headers)
             images = response.json().get("profiles", [])
 
             # Get the 1920x1080 image if available, otherwise use the first available image
             if images:
-                image_url = next(
-                    (
-                        img["file_path"]
-                        for img in images
-                        if img["width"] == 1920 and img["height"] == 1080
-                    ),
-                    images[0]["file_path"],
+                find_1080p_image = (
+                    img["file_path"]
+                    for img in images
+                    if img["width"] == 1920 and img["height"] == 1080
                 )
-                actor_url.append(image_url)
+                image_url = next(find_1080p_image, images[0]["file_path"])
+                actor_urls.append(image_url)
 
             movie["actor_images"] = (
-                actor_url  # note for testing make sure this adds to actor_images and does not overwrite actor images
+                actor_urls  # note for testing make sure this adds to actor_images and does not overwrite actor images
             )
-
-    return movies
+            # TODO: I don't understand what's going on here ^.
 
 
 def related_movies(movies, headers):
     """
-    This function gets the related movies to the movies in our json this is to consider answers that will have the same 4 actors in a sequel
+    Gets the related movies to the given movies (to consider other answers that will have the same 4 actors, e.g. in a
+    sequel)
 
-    :param movies: dict - a dict of movie data
+    :param movies: dict - movie data
     :param headers: dict - api authorization header
-    :return: dict the movies dict with the related movies added
     """
 
     movie_set = None
@@ -174,11 +196,11 @@ def related_movies(movies, headers):
         actor_ids = movie.get("actors", [])
         for actor_id in actor_ids:
             # api endpoint
-            actor_url = "{}person/{}/movie_credits?language=en-US".format(
-                TMDB_BASE_URL, actor_id
-            )
-            actor_response = requests.get(actor_url, headers=headers)
-            actor_movies = actor_response.json().get("cast", [])
+            actor_credits_uri = TMDB_ACTOR_CREDITS_URI_FMT.format(actor_id)
+            url = "{}{}".format(TMDB_BASE_URL, actor_credits_uri)
+            params = {"language": CONTENT_LANGUAGE}
+            response = requests.get(url, params=params, headers=headers)
+            actor_movies = response.json().get("cast", [])
 
             # create a set of the movies and then find the intersection of those sets
             if movie_set is None:
@@ -189,5 +211,3 @@ def related_movies(movies, headers):
 
         # add the alternative answers to the movie json
         movie["alternative_answers"] = movie_set
-
-    return movies

--- a/src/movies.py
+++ b/src/movies.py
@@ -6,17 +6,20 @@ TMDB_BASE_URL = "https://api.themoviedb.org/3/"
 # number of actors that will be used in the game (this will remain at 4)
 NUMBER_OF_ACTORS = 4
 
+
 def popular_movies(pages, headers):
     """
-        This function calls the TMDB API for the popular movies list
-    
-        :param pages: int - number of pages of top rated movies to get there are 20 results on each page
-        :param headers: dict - api authorization header
-        :return: dict return the api response of popular movies
+    This function calls the TMDB API for the popular movies list
+
+    :param pages: int - number of pages of top rated movies to get there are 20 results on each page
+    :param headers: dict - api authorization header
+    :return: dict return the api response of popular movies
     """
-    
+
     # api endpoint
-    url = "{}movie/popular?language=en-US&page={}&region=840".format(TMDB_BASE_URL, pages) # region 840 is USA see https://en.wikipedia.org/wiki/ISO_3166-1 for other country codes
+    url = "{}movie/popular?language=en-US&page={}&region=840".format(
+        TMDB_BASE_URL, pages
+    )  # region 840 is USA see https://en.wikipedia.org/wiki/ISO_3166-1 for other country codes
 
     # use the api url and headers to get the information on the popular movies
     response = requests.get(url, headers=headers)
@@ -24,17 +27,18 @@ def popular_movies(pages, headers):
 
 
 def toprated_movies(pages, headers):
+    """
+    This function calls the TMDB API for the top rated movies list
 
+    :param pages: int - number of pages of top rated movies to get there are 20 results on each page
+    :param headers: dict - api authorization header
+    :return: dict return the api response of top rated movies
     """
-        This function calls the TMDB API for the top rated movies list
-    
-        :param pages: int - number of pages of top rated movies to get there are 20 results on each page
-        :param headers: dict - api authorization header
-        :return: dict return the api response of top rated movies
-    """
-    
+
     # api endpoint
-    url = "{}movie/top_rated?language=en-US&page={}&region=840".format(TMDB_BASE_URL, pages)
+    url = "{}movie/top_rated?language=en-US&page={}&region=840".format(
+        TMDB_BASE_URL, pages
+    )
 
     # use the api url and headers to get the information on the popular movies
     response = requests.get(url, headers=headers)
@@ -43,30 +47,33 @@ def toprated_movies(pages, headers):
 
 def extract_movie_data(movies):
     """
-        Take the movie id and title out of the API results
+    Take the movie id and title out of the API results
 
-        :param movies: dict - a dict of movie data
-        :return: dict return only the extracted data from the movies should be just the ids and the title
+    :param movies: dict - a dict of movie data
+    :return: dict return only the extracted data from the movies should be just the ids and the title
     """
 
     # extract ID and Title
     extracted_data = [
         {"id": movie.get("id"), "title": movie.get("title")}
         for movie in movies.get("results", [])
-        if 16 not in movie.get("genre_ids", []) # genre 16 is animation we are choosing to ignore it for now since it will be difficult to recognize actors
+        if 16
+        not in movie.get(
+            "genre_ids", []
+        )  # genre 16 is animation we are choosing to ignore it for now since it will be difficult to recognize actors
     ]
     return {"movies": extracted_data}
 
 
 def actors(movies, headers):
     """
-        This function gets the actors from a given movie and then calls the popular_actors function to get the most popular ones
+    This function gets the actors from a given movie and then calls the popular_actors function to get the most popular ones
 
-        :param movies: dict - a dict of movie data
-        :param headers: dict - api authorization header
-        :return: dict return the movies dict after adding the most popular actors to each movie
+    :param movies: dict - a dict of movie data
+    :param headers: dict - api authorization header
+    :return: dict return the movies dict after adding the most popular actors to each movie
     """
-    
+
     # run an api call on each movie and get the cast, after that call popular_actors to get the most popular actors and add them to the json
     for movie in movies.get("movies", []):
         movie_id = movie.get("id")
@@ -84,27 +91,27 @@ def actors(movies, headers):
 
 def popular_actors(cast):
     """
-        This is a helper function that gets the most popular actors from a given movie cast.
+    This is a helper function that gets the most popular actors from a given movie cast.
 
-        :param cast: dict - the cast of a certain movie as well as data on the actors one entry looks like this 
-        "cast": [
-            {
-            "adult": false,
-            "gender": 2,
-            "id": 504,
-            "known_for_department": "Acting",
-            "name": "Tim Robbins",
-            "original_name": "Tim Robbins",
-            "popularity": 32.809,
-            "profile_path": "/A4fHNLX73EQs78f2G6ObfKZnvp4.jpg",
-            "cast_id": 3,
-            "character": "Andy Dufresne",
-            "credit_id": "52fe4231c3a36847f800b131",
-            "order": 0
-            }
-        ]
-        
-        :return: dict - return the ids of the most popular actors
+    :param cast: dict - the cast of a certain movie as well as data on the actors one entry looks like this
+    "cast": [
+        {
+        "adult": false,
+        "gender": 2,
+        "id": 504,
+        "known_for_department": "Acting",
+        "name": "Tim Robbins",
+        "original_name": "Tim Robbins",
+        "popularity": 32.809,
+        "profile_path": "/A4fHNLX73EQs78f2G6ObfKZnvp4.jpg",
+        "cast_id": 3,
+        "character": "Andy Dufresne",
+        "credit_id": "52fe4231c3a36847f800b131",
+        "order": 0
+        }
+    ]
+
+    :return: dict - return the ids of the most popular actors
     """
     # sort the cast list based on popularity in descending order
     sorted_cast = sorted(cast["cast"], key=lambda x: x["popularity"], reverse=True)
@@ -116,11 +123,11 @@ def popular_actors(cast):
 
 def actor_images(movies, headers):
     """
-        This function gets the actors images from the api
+    This function gets the actors images from the api
 
-        :param movies: dict - a dict of movie data
-        :param headers: dict - api authorization header
-        :return: dict the updated movies dict with pictures of the actors 
+    :param movies: dict - a dict of movie data
+    :param headers: dict - api authorization header
+    :return: dict the updated movies dict with pictures of the actors
     """
     actor_url = []
 
@@ -135,21 +142,30 @@ def actor_images(movies, headers):
 
             # Get the 1920x1080 image if available, otherwise use the first available image
             if images:
-                image_url = next((img["file_path"] for img in images if img["width"] == 1920 and img["height"] == 1080), images[0]["file_path"])
+                image_url = next(
+                    (
+                        img["file_path"]
+                        for img in images
+                        if img["width"] == 1920 and img["height"] == 1080
+                    ),
+                    images[0]["file_path"],
+                )
                 actor_url.append(image_url)
 
-            movie["actor_images"] = actor_url # note for testing make sure this adds to actor_images and does not overwrite actor images
-    
+            movie["actor_images"] = (
+                actor_url  # note for testing make sure this adds to actor_images and does not overwrite actor images
+            )
+
     return movies
 
 
 def related_movies(movies, headers):
     """
-        This function gets the related movies to the movies in our json this is to consider answers that will have the same 4 actors in a sequel
+    This function gets the related movies to the movies in our json this is to consider answers that will have the same 4 actors in a sequel
 
-        :param movies: dict - a dict of movie data
-        :param headers: dict - api authorization header
-        :return: dict the movies dict with the related movies added
+    :param movies: dict - a dict of movie data
+    :param headers: dict - api authorization header
+    :return: dict the movies dict with the related movies added
     """
 
     movie_set = None
@@ -158,10 +174,12 @@ def related_movies(movies, headers):
         actor_ids = movie.get("actors", [])
         for actor_id in actor_ids:
             # api endpoint
-            actor_url = "{}person/{}/movie_credits?language=en-US".format(TMDB_BASE_URL, actor_id)
+            actor_url = "{}person/{}/movie_credits?language=en-US".format(
+                TMDB_BASE_URL, actor_id
+            )
             actor_response = requests.get(actor_url, headers=headers)
             actor_movies = actor_response.json().get("cast", [])
-            
+
             # create a set of the movies and then find the intersection of those sets
             if movie_set is None:
                 movie_set = set(m["title"] for m in actor_movies)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,8 +1,33 @@
-import pytest
+from unittest.mock import patch
 
-from src.main import (
-    main,
-)
+from src.main import main
 
-def test_main():
-    main()
+@patch("src.main.related_movies")
+@patch("src.main.actor_images")
+@patch("src.main.actors")
+@patch("src.main.extract_movie_data")
+@patch("src.main.toprated_movies")
+def test_main(
+    mock_toprated_movies,
+    mock_extract_movie_data,
+    mock_actors,
+    mock_actor_images,
+    mock_related_movies,
+):
+    mock_toprated_movies.return_value = {"data": "mock-data-1"}
+    mock_extract_movie_data.return_value = {"data": "mock-data-2"}
+
+    mock_api_token = "mock-api-token"
+    expected_headers = {
+        "Accept": "application/json",
+        "Authorization": "Bearer mock-api-token",
+    }
+
+    with patch.dict("src.main.env_vars", {"TMDB_API_TOKEN": mock_api_token}, clear=True):
+        main()
+
+    mock_toprated_movies.assert_called_once_with(1, expected_headers)
+    mock_extract_movie_data.assert_called_once_with({"data": "mock-data-1"})
+    mock_actors.assert_called_once_with({"data": "mock-data-2"}, expected_headers)
+    mock_actor_images.assert_called_once()
+    mock_related_movies.assert_called_once()

--- a/tests/unit/test_movies.py
+++ b/tests/unit/test_movies.py
@@ -20,8 +20,7 @@ def test_popular_movies():
                     "id": 609681
                 }
             ]
-        }
-        )
+        })
         expected = { # I think make expected the same as the mock request
             "page": 1,
             "results": [
@@ -32,7 +31,7 @@ def test_popular_movies():
         }
         actual = src.movies.popular_movies(1, headers) # call the request with popular_movies
         assert actual == expected # if popular_movies calls the correct endpoint then our assertion will be true
-    
+
 
 def test_toprated_movies():
     # api authorization
@@ -71,8 +70,8 @@ def test_extract_movie_data():
             {
                 "backdrop_path": "/kXfqcdQKsToO0OUXHcrrNCHDBzO.jpg",
                 "genre_ids": [
-                18,
-                80
+                    18,
+                    80
                 ],
                 "id": 278,
                 "original_language": "en",
@@ -88,8 +87,8 @@ def test_extract_movie_data():
             {
                 "backdrop_path": "/rSPw7tgCH9c6NqICZef4kZjFOQ5.jpg",
                 "genre_ids": [
-                18,
-                80
+                    18,
+                    80
                 ],
                 "id": 238,
                 "original_language": "en",
@@ -105,8 +104,8 @@ def test_extract_movie_data():
             {
                 "backdrop_path": "/kGzFbGhp99zva6oZODW5atUtnqi.jpg",
                 "genre_ids": [
-                18,
-                80
+                    18,
+                    80
                 ],
                 "id": 240,
                 "original_language": "en",
@@ -121,21 +120,21 @@ def test_extract_movie_data():
             }
         ]
     }
-        
+
     expected = {
         "movies": [
-                {
+            {
                 "id": 278,
                 "title": "The Shawshank Redemption"
-                },
-                {
+            },
+            {
                 "id": 238,
                 "title": "The Godfather"
-                },
-                {
+            },
+            {
                 "id": 240,
                 "title": "The Godfather Part II"
-                }
+            }
         ]
     }
     actual = src.movies.extract_movie_data(data)
@@ -147,9 +146,9 @@ def test_extract_movie_data():
             {
                 "backdrop_path": "/kXfqcdQKsToO0OUXHcrrNCHDBzO.jpg",
                 "genre_ids": [
-                18,
-                80,
-                16
+                    18,
+                    80,
+                    16
                 ],
                 "id": 278,
                 "original_language": "en",
@@ -165,8 +164,8 @@ def test_extract_movie_data():
             {
                 "backdrop_path": "/rSPw7tgCH9c6NqICZef4kZjFOQ5.jpg",
                 "genre_ids": [
-                18,
-                80
+                    18,
+                    80
                 ],
                 "id": 238,
                 "original_language": "en",
@@ -182,8 +181,8 @@ def test_extract_movie_data():
             {
                 "backdrop_path": "/kGzFbGhp99zva6oZODW5atUtnqi.jpg",
                 "genre_ids": [
-                18,
-                80
+                    18,
+                    80
                 ],
                 "id": 240,
                 "original_language": "en",
@@ -198,17 +197,17 @@ def test_extract_movie_data():
             }
         ]
     }
-        
+
     expected = {
         "movies": [
-                {
+            {
                 "id": 238,
                 "title": "The Godfather"
-                },
-                {
+            },
+            {
                 "id": 240,
                 "title": "The Godfather Part II"
-                }
+            }
         ]
     }
 
@@ -224,11 +223,11 @@ def test_actors():
     }
 
     # copied the same testing style as popular movies refer to that for more detailed comments.
-    with requests_mock.Mocker() as mock_requests:      
+    with requests_mock.Mocker() as mock_requests:
         mock_requests.get("https://api.themoviedb.org/3/movie/278/credits?language=en-US", json={
             "id": 278,
             "cast": [
-                    {
+                {
                     "gender": 2,
                     "id": 504,
                     "known_for_department": "Acting",
@@ -240,8 +239,8 @@ def test_actors():
                     "character": "Andy Dufresne",
                     "credit_id": "52fe4231c3a36847f800b131",
                     "order": 0
-                    },
-                    {
+                },
+                {
                     "gender": 2,
                     "id": 192,
                     "known_for_department": "Acting",
@@ -253,8 +252,8 @@ def test_actors():
                     "character": "Ellis Boyd 'Red' Redding",
                     "credit_id": "52fe4231c3a36847f800b135",
                     "order": 1
-                    },
-                    {
+                },
+                {
                     "gender": 2,
                     "id": 4029,
                     "known_for_department": "Acting",
@@ -266,8 +265,8 @@ def test_actors():
                     "character": "Warden Norton",
                     "credit_id": "52fe4231c3a36847f800b139",
                     "order": 2
-                    },
-                    {
+                },
+                {
                     "gender": 2,
                     "id": 6573,
                     "known_for_department": "Acting",
@@ -279,8 +278,8 @@ def test_actors():
                     "character": "Heywood",
                     "credit_id": "52fe4231c3a36847f800b13d",
                     "order": 3
-                    },
-                    {
+                },
+                {
                     "gender": 2,
                     "id": 6574,
                     "known_for_department": "Acting",
@@ -292,8 +291,8 @@ def test_actors():
                     "character": "Captain Byron T. Hadley",
                     "credit_id": "52fe4231c3a36847f800b141",
                     "order": 4
-                    },
-                    {
+                },
+                {
                     "gender": 2,
                     "id": 6575,
                     "known_for_department": "Acting",
@@ -305,8 +304,8 @@ def test_actors():
                     "character": "Tommy",
                     "credit_id": "52fe4231c3a36847f800b145",
                     "order": 5
-                    },
-                    {
+                },
+                {
                     "gender": 2,
                     "id": 6577,
                     "known_for_department": "Acting",
@@ -318,8 +317,8 @@ def test_actors():
                     "character": "Brooks Hatlen",
                     "credit_id": "52fe4231c3a36847f800b14d",
                     "order": 6
-                    },
-                    {
+                },
+                {
                     "gender": 2,
                     "id": 6576,
                     "known_for_department": "Acting",
@@ -331,137 +330,136 @@ def test_actors():
                     "character": "Bogs Diamond",
                     "credit_id": "52fe4231c3a36847f800b149",
                     "order": 7
-                    }
-                ]
-        }
-        )
+                }
+            ]
+        })
         expected = {'movies': [{'id': 278, 'title': "The Shawshank Redemption", 'actors': [192, 6574, 6573, 504]}]}
 
         data = {
-        "movies": [
+            "movies": [
                 {
-                "id": 278,
-                "title": "The Shawshank Redemption"
+                    "id": 278,
+                    "title": "The Shawshank Redemption"
                 }
-        ]
+            ]
         }
 
-        actual = src.movies.actors(data, headers)
-        assert actual == expected
+        src.movies.actors(data, headers)
+        assert data == expected
 
 
 def test_popular_actors():
     # create a fake cast output from the api
     cast={
-            "id": 278,
-            "cast": [
-                    {
-                    "gender": 2,
-                    "id": 504,
-                    "known_for_department": "Acting",
-                    "name": "Tim Robbins",
-                    "original_name": "Tim Robbins",
-                    "popularity": 32.322,
-                    "profile_path": "/A4fHNLX73EQs78f2G6ObfKZnvp4.jpg",
-                    "cast_id": 3,
-                    "character": "Andy Dufresne",
-                    "credit_id": "52fe4231c3a36847f800b131",
-                    "order": 0
-                    },
-                    {
-                    "gender": 2,
-                    "id": 192,
-                    "known_for_department": "Acting",
-                    "name": "Morgan Freeman",
-                    "original_name": "Morgan Freeman",
-                    "popularity": 119.503,
-                    "profile_path": "/jPsLqiYGSofU4s6BjrxnefMfabb.jpg",
-                    "cast_id": 4,
-                    "character": "Ellis Boyd 'Red' Redding",
-                    "credit_id": "52fe4231c3a36847f800b135",
-                    "order": 1
-                    },
-                    {
-                    "gender": 2,
-                    "id": 4029,
-                    "known_for_department": "Acting",
-                    "name": "Bob Gunton",
-                    "original_name": "Bob Gunton",
-                    "popularity": 29.707,
-                    "profile_path": "/ulbVvuBToBN3aCGcV028hwO0MOP.jpg",
-                    "cast_id": 5,
-                    "character": "Warden Norton",
-                    "credit_id": "52fe4231c3a36847f800b139",
-                    "order": 2
-                    },
-                    {
-                    "gender": 2,
-                    "id": 6573,
-                    "known_for_department": "Acting",
-                    "name": "William Sadler",
-                    "original_name": "William Sadler",
-                    "popularity": 40.262,
-                    "profile_path": "/rWeb2kjYCA7V9MC9kRwRpm57YoY.jpg",
-                    "cast_id": 7,
-                    "character": "Heywood",
-                    "credit_id": "52fe4231c3a36847f800b13d",
-                    "order": 3
-                    },
-                    {
-                    "gender": 2,
-                    "id": 6574,
-                    "known_for_department": "Acting",
-                    "name": "Clancy Brown",
-                    "original_name": "Clancy Brown",
-                    "popularity": 60.126,
-                    "profile_path": "/9RgzFqbmWBLVfq9wvyDo5UW8VT1.jpg",
-                    "cast_id": 8,
-                    "character": "Captain Byron T. Hadley",
-                    "credit_id": "52fe4231c3a36847f800b141",
-                    "order": 4
-                    },
-                    {
-                    "gender": 2,
-                    "id": 6575,
-                    "known_for_department": "Acting",
-                    "name": "Gil Bellows",
-                    "original_name": "Gil Bellows",
-                    "popularity": 27.165,
-                    "profile_path": "/eCOIv2nSGnWTHdn88NoMyNOKWyR.jpg",
-                    "cast_id": 9,
-                    "character": "Tommy",
-                    "credit_id": "52fe4231c3a36847f800b145",
-                    "order": 5
-                    },
-                    {
-                    "gender": 2,
-                    "id": 6577,
-                    "known_for_department": "Acting",
-                    "name": "James Whitmore",
-                    "original_name": "James Whitmore",
-                    "popularity": 20.057,
-                    "profile_path": "/d1nOu22OvPzdwS8euWE0FNHwx8K.jpg",
-                    "cast_id": 11,
-                    "character": "Brooks Hatlen",
-                    "credit_id": "52fe4231c3a36847f800b14d",
-                    "order": 6
-                    },
-                    {
-                    "gender": 2,
-                    "id": 6576,
-                    "known_for_department": "Acting",
-                    "name": "Mark Rolston",
-                    "original_name": "Mark Rolston",
-                    "popularity": 15.239,
-                    "profile_path": "/hcrNRIptYMRXgkJ9k76BlQu6DQp.jpg",
-                    "cast_id": 10,
-                    "character": "Bogs Diamond",
-                    "credit_id": "52fe4231c3a36847f800b149",
-                    "order": 7
-                    }
-                ]
-        }
-    
+        "id": 278,
+        "cast": [
+            {
+                "gender": 2,
+                "id": 504,
+                "known_for_department": "Acting",
+                "name": "Tim Robbins",
+                "original_name": "Tim Robbins",
+                "popularity": 32.322,
+                "profile_path": "/A4fHNLX73EQs78f2G6ObfKZnvp4.jpg",
+                "cast_id": 3,
+                "character": "Andy Dufresne",
+                "credit_id": "52fe4231c3a36847f800b131",
+                "order": 0
+            },
+            {
+                "gender": 2,
+                "id": 192,
+                "known_for_department": "Acting",
+                "name": "Morgan Freeman",
+                "original_name": "Morgan Freeman",
+                "popularity": 119.503,
+                "profile_path": "/jPsLqiYGSofU4s6BjrxnefMfabb.jpg",
+                "cast_id": 4,
+                "character": "Ellis Boyd 'Red' Redding",
+                "credit_id": "52fe4231c3a36847f800b135",
+                "order": 1
+            },
+            {
+                "gender": 2,
+                "id": 4029,
+                "known_for_department": "Acting",
+                "name": "Bob Gunton",
+                "original_name": "Bob Gunton",
+                "popularity": 29.707,
+                "profile_path": "/ulbVvuBToBN3aCGcV028hwO0MOP.jpg",
+                "cast_id": 5,
+                "character": "Warden Norton",
+                "credit_id": "52fe4231c3a36847f800b139",
+                "order": 2
+            },
+            {
+                "gender": 2,
+                "id": 6573,
+                "known_for_department": "Acting",
+                "name": "William Sadler",
+                "original_name": "William Sadler",
+                "popularity": 40.262,
+                "profile_path": "/rWeb2kjYCA7V9MC9kRwRpm57YoY.jpg",
+                "cast_id": 7,
+                "character": "Heywood",
+                "credit_id": "52fe4231c3a36847f800b13d",
+                "order": 3
+            },
+            {
+                "gender": 2,
+                "id": 6574,
+                "known_for_department": "Acting",
+                "name": "Clancy Brown",
+                "original_name": "Clancy Brown",
+                "popularity": 60.126,
+                "profile_path": "/9RgzFqbmWBLVfq9wvyDo5UW8VT1.jpg",
+                "cast_id": 8,
+                "character": "Captain Byron T. Hadley",
+                "credit_id": "52fe4231c3a36847f800b141",
+                "order": 4
+            },
+            {
+                "gender": 2,
+                "id": 6575,
+                "known_for_department": "Acting",
+                "name": "Gil Bellows",
+                "original_name": "Gil Bellows",
+                "popularity": 27.165,
+                "profile_path": "/eCOIv2nSGnWTHdn88NoMyNOKWyR.jpg",
+                "cast_id": 9,
+                "character": "Tommy",
+                "credit_id": "52fe4231c3a36847f800b145",
+                "order": 5
+            },
+            {
+                "gender": 2,
+                "id": 6577,
+                "known_for_department": "Acting",
+                "name": "James Whitmore",
+                "original_name": "James Whitmore",
+                "popularity": 20.057,
+                "profile_path": "/d1nOu22OvPzdwS8euWE0FNHwx8K.jpg",
+                "cast_id": 11,
+                "character": "Brooks Hatlen",
+                "credit_id": "52fe4231c3a36847f800b14d",
+                "order": 6
+            },
+            {
+                "gender": 2,
+                "id": 6576,
+                "known_for_department": "Acting",
+                "name": "Mark Rolston",
+                "original_name": "Mark Rolston",
+                "popularity": 15.239,
+                "profile_path": "/hcrNRIptYMRXgkJ9k76BlQu6DQp.jpg",
+                "cast_id": 10,
+                "character": "Bogs Diamond",
+                "credit_id": "52fe4231c3a36847f800b149",
+                "order": 7
+            }
+        ]
+    }
+
     # ensure the parsing is working correctly
     expected = [192, 6574, 6573, 504]
     actual = src.movies.popular_actors(cast)
@@ -469,7 +467,6 @@ def test_popular_actors():
 
 
 def test_actor_images():
-    
     # api authorization
     headers = {
         "accept": "accept",
@@ -481,579 +478,572 @@ def test_actor_images():
             "id": 192,
             "profiles": [
                 {
-                "aspect_ratio": 0.667,
-                "height": 2700,
-                "file_path": "/jPsLqiYGSofU4s6BjrxnefMfabb.jpg",
-                "vote_average": 5.326,
-                "vote_count": 7,
-                "width": 1800
+                    "aspect_ratio": 0.667,
+                    "height": 2700,
+                    "file_path": "/jPsLqiYGSofU4s6BjrxnefMfabb.jpg",
+                    "vote_average": 5.326,
+                    "vote_count": 7,
+                    "width": 1800
                 },
                 {
-                "aspect_ratio": 0.667,
-                "height": 3000,
-                "file_path": "/905k0RFzH0Kd6gx8oSxRdnr6FL.jpg",
-                "vote_average": 5.264,
-                "vote_count": 8,
-                "width": 2000
+                    "aspect_ratio": 0.667,
+                    "height": 3000,
+                    "file_path": "/905k0RFzH0Kd6gx8oSxRdnr6FL.jpg",
+                    "vote_average": 5.264,
+                    "vote_count": 8,
+                    "width": 2000
                 },
                 {
-                "aspect_ratio": 0.667,
-                "height": 1920,
-                "file_path": "/nhFqNPXDyWTRzHqIUqwayfvDmCn.jpg",
-                "vote_average": 5.258,
-                "vote_count": 6,
-                "width": 1280
+                    "aspect_ratio": 0.667,
+                    "height": 1920,
+                    "file_path": "/nhFqNPXDyWTRzHqIUqwayfvDmCn.jpg",
+                    "vote_average": 5.258,
+                    "vote_count": 6,
+                    "width": 1280
                 },
                 {
-                "aspect_ratio": 0.667,
-                "height": 999,
-                "file_path": "/iRl1tJADZhnkTcirVm21zs8kJhH.jpg",
-                "vote_average": 5.198,
-                "vote_count": 7,
-                "width": 666
+                    "aspect_ratio": 0.667,
+                    "height": 999,
+                    "file_path": "/iRl1tJADZhnkTcirVm21zs8kJhH.jpg",
+                    "vote_average": 5.198,
+                    "vote_count": 7,
+                    "width": 666
                 },
                 {
-                "aspect_ratio": 0.667,
-                "height": 3000,
-                "file_path": "/1ahENoyEgKSbRUd0IsydIff7rt1.jpg",
-                "vote_average": 5.19,
-                "vote_count": 5,
-                "width": 2000
+                    "aspect_ratio": 0.667,
+                    "height": 3000,
+                    "file_path": "/1ahENoyEgKSbRUd0IsydIff7rt1.jpg",
+                    "vote_average": 5.19,
+                    "vote_count": 5,
+                    "width": 2000
                 },
                 {
-                "aspect_ratio": 0.667,
-                "height": 1920,
-                "file_path": "/iuX6R4Sfm6FK5nbfSQ8OgvWcOjy.jpg",
-                "vote_average": 5.18,
-                "vote_count": 3,
-                "width": 1280
+                    "aspect_ratio": 0.667,
+                    "height": 1920,
+                    "file_path": "/iuX6R4Sfm6FK5nbfSQ8OgvWcOjy.jpg",
+                    "vote_average": 5.18,
+                    "vote_count": 3,
+                    "width": 1280
                 }
             ]
-        }
-        )
+        })
         mock_requests.get("https://api.themoviedb.org/3/person/6574/images", json={
             "id": 6574,
             "profiles": [
                 {
-                "aspect_ratio": 0.667,
-                "height": 1500,
-                "file_path": "/9RgzFqbmWBLVfq9wvyDo5UW8VT1.jpg",
-                "vote_average": 5.27,
-                "vote_count": 10,
-                "width": 1000
+                    "aspect_ratio": 0.667,
+                    "height": 1500,
+                    "file_path": "/9RgzFqbmWBLVfq9wvyDo5UW8VT1.jpg",
+                    "vote_average": 5.27,
+                    "vote_count": 10,
+                    "width": 1000
                 },
                 {
-                "aspect_ratio": 0.667,
-                "height": 750,
-                "file_path": "/xjg0ZIxP0tFcEQCTeRgKxNtLdpe.jpg",
-                "vote_average": 5.264,
-                "vote_count": 8,
-                "width": 500
+                    "aspect_ratio": 0.667,
+                    "height": 750,
+                    "file_path": "/xjg0ZIxP0tFcEQCTeRgKxNtLdpe.jpg",
+                    "vote_average": 5.264,
+                    "vote_count": 8,
+                    "width": 500
                 },
                 {
-                "aspect_ratio": 0.667,
-                "height": 1500,
-                "file_path": "/uzkU71DkwwRyO7qxwD0A254PjAS.jpg",
-                "vote_average": 5.19,
-                "vote_count": 5,
-                "width": 1000
+                    "aspect_ratio": 0.667,
+                    "height": 1500,
+                    "file_path": "/uzkU71DkwwRyO7qxwD0A254PjAS.jpg",
+                    "vote_average": 5.19,
+                    "vote_count": 5,
+                    "width": 1000
                 },
                 {
-                "aspect_ratio": 0.667,
-                "height": 900,
-                "file_path": "/ekaX4du53NcOeEmce7nsk564cBZ.jpg",
-                "vote_average": 5.18,
-                "vote_count": 3,
-                "width": 600
+                    "aspect_ratio": 0.667,
+                    "height": 900,
+                    "file_path": "/ekaX4du53NcOeEmce7nsk564cBZ.jpg",
+                    "vote_average": 5.18,
+                    "vote_count": 3,
+                    "width": 600
                 },
                 {
-                "aspect_ratio": 0.667,
-                "height": 2048,
-                "file_path": "/9UwM8st1EdHIJIlJXD2N9PWA8uG.jpg",
-                "vote_average": 5.146,
-                "vote_count": 10,
-                "width": 1365
+                    "aspect_ratio": 0.667,
+                    "height": 2048,
+                    "file_path": "/9UwM8st1EdHIJIlJXD2N9PWA8uG.jpg",
+                    "vote_average": 5.146,
+                    "vote_count": 10,
+                    "width": 1365
                 }
             ]
-            }
-        )
+        })
 
         expected = {'movies': [{'id': 278, 'title': "The Shawshank Redemption", 'actors': [192, 6574], 'actor_images': ["/jPsLqiYGSofU4s6BjrxnefMfabb.jpg", "/9RgzFqbmWBLVfq9wvyDo5UW8VT1.jpg"]}]}
-        input = {'movies': [{'id': 278, 'title': "The Shawshank Redemption", 'actors': [192, 6574]}]}
-        actual = src.movies.actor_images(input, headers)
-        assert actual == expected
+        data = {'movies': [{'id': 278, 'title': "The Shawshank Redemption", 'actors': [192, 6574]}]}
+        src.movies.actor_images(data, headers)
+        assert data == expected
 
 
 def test_related_movies():
-
     # api authorization
     headers = {
         "accept": "accept",
         "Authorization": "authorization"
     }
-    
+
     with requests_mock.Mocker() as mock_requests:
         mock_requests.get("https://api.themoviedb.org/3/person/109/movie_credits?language=en-US", json={
-  "cast": [
-    {
-      "adult": False,
-      "backdrop_path": "/jz9Kep0xWjiA6QDHSsd43ASxNfj.jpg",
-      "genre_ids": [
-        878,
-        18,
-        10749
-      ],
-      "id": 38,
-      "original_language": "en",
-      "original_title": "Eternal Sunshine of the Spotless Mind",
-      "overview": "Joel Barish, heartbroken that his girlfriend underwent a procedure to erase him from her memory, decides to do the same. However, as he watches his memories of her fade away, he realises that he still loves her, and may be too late to correct his mistake.",
-      "popularity": 81.875,
-      "poster_path": "/5MwkWH9tYHv3mV9OdYTMR5qreIz.jpg",
-      "release_date": "2004-03-19",
-      "title": "Eternal Sunshine of the Spotless Mind",
-      "video": False,
-      "vote_average": 8.097,
-      "vote_count": 14398,
-      "character": "Patrick",
-      "credit_id": "52fe4211c3a36847f8001677",
-      "order": 4
-    },
-    {
-      "adult": False,
-      "backdrop_path": "/6G73mNyooWAEQTpckPSnFxFoNmc.jpg",
-      "genre_ids": [
-        12,
-        14,
-        28
-      ],
-      "id": 121,
-      "original_language": "en",
-      "original_title": "The Lord of the Rings: The Two Towers",
-      "overview": "Frodo and Sam are trekking to Mordor to destroy the One Ring of Power while Gimli, Legolas and Aragorn search for the orc-captured Merry and Pippin. All along, nefarious wizard Saruman awaits the Fellowship members at the Orthanc Tower in Isengard.",
-      "popularity": 115.753,
-      "poster_path": "/5VTN0pR8gcqV3EPUHHfMGnJYN9L.jpg",
-      "release_date": "2002-12-18",
-      "title": "The Lord of the Rings: The Two Towers",
-      "video": False,
-      "vote_average": 8.4,
-      "vote_count": 21140,
-      "character": "Frodo Baggins",
-      "credit_id": "52fe421ac3a36847f8004589",
-      "order": 0
-    },
-    {
-      "adult": False,
-      "backdrop_path": "/2u7zbn8EudG6kLlBzUYqP8RyFU4.jpg",
-      "genre_ids": [
-        12,
-        14,
-        28
-      ],
-      "id": 122,
-      "original_language": "en",
-      "original_title": "The Lord of the Rings: The Return of the King",
-      "overview": "Aragorn is revealed as the heir to the ancient kings as he, Gandalf and the other members of the broken fellowship struggle to save Gondor from Sauron's forces. Meanwhile, Frodo and Sam take the ring closer to the heart of Mordor, the dark lord's realm.",
-      "popularity": 132.611,
-      "poster_path": "/rCzpDGLbOoPwLjy3OAm5NUPOTrC.jpg",
-      "release_date": "2003-12-01",
-      "title": "The Lord of the Rings: The Return of the King",
-      "video": False,
-      "vote_average": 8.5,
-      "vote_count": 23384,
-      "character": "Frodo Baggins",
-      "credit_id": "52fe421bc3a36847f80046f7",
-      "order": 0
-    },
-    {
-      "adult": False,
-      "backdrop_path": "/x2RS3uTcsJJ9IfjNPcgDmukoEcQ.jpg",
-      "genre_ids": [
-        12,
-        14,
-        28
-      ],
-      "id": 120,
-      "original_language": "en",
-      "original_title": "The Lord of the Rings: The Fellowship of the Ring",
-      "overview": "Young hobbit Frodo Baggins, after inheriting a mysterious ring from his uncle Bilbo, must leave his home in order to keep it from falling into the hands of its evil creator. Along the way, a fellowship is formed to protect the ringbearer and make sure that the ring arrives at its final destination: Mt. Doom, the only place where it can be destroyed.",
-      "popularity": 164.708,
-      "poster_path": "/6oom5QYQ2yQTMJIbnvbkBL9cHo6.jpg",
-      "release_date": "2001-12-18",
-      "title": "The Lord of the Rings: The Fellowship of the Ring",
-      "video": False,
-      "vote_average": 8.4,
-      "vote_count": 24324,
-      "character": "Frodo Baggins",
-      "credit_id": "52fe421ac3a36847f800448f",
-      "order": 0
-    }
+            "cast": [
+                {
+                    "adult": False,
+                    "backdrop_path": "/jz9Kep0xWjiA6QDHSsd43ASxNfj.jpg",
+                    "genre_ids": [
+                        878,
+                        18,
+                        10749
+                    ],
+                    "id": 38,
+                    "original_language": "en",
+                    "original_title": "Eternal Sunshine of the Spotless Mind",
+                    "overview": "Joel Barish, heartbroken that his girlfriend underwent a procedure to erase him from her memory, decides to do the same. However, as he watches his memories of her fade away, he realises that he still loves her, and may be too late to correct his mistake.",
+                    "popularity": 81.875,
+                    "poster_path": "/5MwkWH9tYHv3mV9OdYTMR5qreIz.jpg",
+                    "release_date": "2004-03-19",
+                    "title": "Eternal Sunshine of the Spotless Mind",
+                    "video": False,
+                    "vote_average": 8.097,
+                    "vote_count": 14398,
+                    "character": "Patrick",
+                    "credit_id": "52fe4211c3a36847f8001677",
+                    "order": 4
+                },
+                {
+                    "adult": False,
+                    "backdrop_path": "/6G73mNyooWAEQTpckPSnFxFoNmc.jpg",
+                    "genre_ids": [
+                        12,
+                        14,
+                        28
+                    ],
+                    "id": 121,
+                    "original_language": "en",
+                    "original_title": "The Lord of the Rings: The Two Towers",
+                    "overview": "Frodo and Sam are trekking to Mordor to destroy the One Ring of Power while Gimli, Legolas and Aragorn search for the orc-captured Merry and Pippin. All along, nefarious wizard Saruman awaits the Fellowship members at the Orthanc Tower in Isengard.",
+                    "popularity": 115.753,
+                    "poster_path": "/5VTN0pR8gcqV3EPUHHfMGnJYN9L.jpg",
+                    "release_date": "2002-12-18",
+                    "title": "The Lord of the Rings: The Two Towers",
+                    "video": False,
+                    "vote_average": 8.4,
+                    "vote_count": 21140,
+                    "character": "Frodo Baggins",
+                    "credit_id": "52fe421ac3a36847f8004589",
+                    "order": 0
+                },
+                {
+                    "adult": False,
+                    "backdrop_path": "/2u7zbn8EudG6kLlBzUYqP8RyFU4.jpg",
+                    "genre_ids": [
+                        12,
+                        14,
+                        28
+                    ],
+                    "id": 122,
+                    "original_language": "en",
+                    "original_title": "The Lord of the Rings: The Return of the King",
+                    "overview": "Aragorn is revealed as the heir to the ancient kings as he, Gandalf and the other members of the broken fellowship struggle to save Gondor from Sauron's forces. Meanwhile, Frodo and Sam take the ring closer to the heart of Mordor, the dark lord's realm.",
+                    "popularity": 132.611,
+                    "poster_path": "/rCzpDGLbOoPwLjy3OAm5NUPOTrC.jpg",
+                    "release_date": "2003-12-01",
+                    "title": "The Lord of the Rings: The Return of the King",
+                    "video": False,
+                    "vote_average": 8.5,
+                    "vote_count": 23384,
+                    "character": "Frodo Baggins",
+                    "credit_id": "52fe421bc3a36847f80046f7",
+                    "order": 0
+                },
+                {
+                    "adult": False,
+                    "backdrop_path": "/x2RS3uTcsJJ9IfjNPcgDmukoEcQ.jpg",
+                    "genre_ids": [
+                        12,
+                        14,
+                        28
+                    ],
+                    "id": 120,
+                    "original_language": "en",
+                    "original_title": "The Lord of the Rings: The Fellowship of the Ring",
+                    "overview": "Young hobbit Frodo Baggins, after inheriting a mysterious ring from his uncle Bilbo, must leave his home in order to keep it from falling into the hands of its evil creator. Along the way, a fellowship is formed to protect the ringbearer and make sure that the ring arrives at its final destination: Mt. Doom, the only place where it can be destroyed.",
+                    "popularity": 164.708,
+                    "poster_path": "/6oom5QYQ2yQTMJIbnvbkBL9cHo6.jpg",
+                    "release_date": "2001-12-18",
+                    "title": "The Lord of the Rings: The Fellowship of the Ring",
+                    "video": False,
+                    "vote_average": 8.4,
+                    "vote_count": 24324,
+                    "character": "Frodo Baggins",
+                    "credit_id": "52fe421ac3a36847f800448f",
+                    "order": 0
+                }
             ]
-        }
-        )
+        })
         mock_requests.get("https://api.themoviedb.org/3/person/1327/movie_credits?language=en-US", json={
             "cast": [
                 {
-                "adult": False,
-                "backdrop_path": "/5EEdDTV0IBxJ2J4jDUDvl076v7f.jpg",
-                "genre_ids": [
-                    18,
-                    53,
-                    80
-                ],
-                "id": 59,
-                "original_language": "en",
-                "original_title": "A History of Violence",
-                "overview": "An average family is thrust into the spotlight after the father commits a seemingly self-defense murder at his diner.",
-                "popularity": 31.45,
-                "poster_path": "/3qnO72NHmUgs9JZXAmu4aId9QDl.jpg",
-                "release_date": "2005-09-23",
-                "title": "A History of Violence",
-                "video": False,
-                "vote_average": 7.168,
-                "vote_count": 3072,
-                "character": "Tom Stall / Joey Cusack",
-                "credit_id": "52fe4212c3a36847f8001927",
-                "order": 0
+                    "adult": False,
+                    "backdrop_path": "/5EEdDTV0IBxJ2J4jDUDvl076v7f.jpg",
+                    "genre_ids": [
+                        18,
+                        53,
+                        80
+                    ],
+                    "id": 59,
+                    "original_language": "en",
+                    "original_title": "A History of Violence",
+                    "overview": "An average family is thrust into the spotlight after the father commits a seemingly self-defense murder at his diner.",
+                    "popularity": 31.45,
+                    "poster_path": "/3qnO72NHmUgs9JZXAmu4aId9QDl.jpg",
+                    "release_date": "2005-09-23",
+                    "title": "A History of Violence",
+                    "video": False,
+                    "vote_average": 7.168,
+                    "vote_count": 3072,
+                    "character": "Tom Stall / Joey Cusack",
+                    "credit_id": "52fe4212c3a36847f8001927",
+                    "order": 0
                 },
                 {
-                "adult": False,
-                "backdrop_path": "/6G73mNyooWAEQTpckPSnFxFoNmc.jpg",
-                "genre_ids": [
-                    12,
-                    14,
-                    28
-                ],
-                "id": 121,
-                "original_language": "en",
-                "original_title": "The Lord of the Rings: The Two Towers",
-                "overview": "Frodo and Sam are trekking to Mordor to destroy the One Ring of Power while Gimli, Legolas and Aragorn search for the orc-captured Merry and Pippin. All along, nefarious wizard Saruman awaits the Fellowship members at the Orthanc Tower in Isengard.",
-                "popularity": 115.753,
-                "poster_path": "/5VTN0pR8gcqV3EPUHHfMGnJYN9L.jpg",
-                "release_date": "2002-12-18",
-                "title": "The Lord of the Rings: The Two Towers",
-                "video": False,
-                "vote_average": 8.4,
-                "vote_count": 21140,
-                "character": "Aragorn",
-                "credit_id": "52fe421ac3a36847f8004591",
-                "order": 4
+                    "adult": False,
+                    "backdrop_path": "/6G73mNyooWAEQTpckPSnFxFoNmc.jpg",
+                    "genre_ids": [
+                        12,
+                        14,
+                        28
+                    ],
+                    "id": 121,
+                    "original_language": "en",
+                    "original_title": "The Lord of the Rings: The Two Towers",
+                    "overview": "Frodo and Sam are trekking to Mordor to destroy the One Ring of Power while Gimli, Legolas and Aragorn search for the orc-captured Merry and Pippin. All along, nefarious wizard Saruman awaits the Fellowship members at the Orthanc Tower in Isengard.",
+                    "popularity": 115.753,
+                    "poster_path": "/5VTN0pR8gcqV3EPUHHfMGnJYN9L.jpg",
+                    "release_date": "2002-12-18",
+                    "title": "The Lord of the Rings: The Two Towers",
+                    "video": False,
+                    "vote_average": 8.4,
+                    "vote_count": 21140,
+                    "character": "Aragorn",
+                    "credit_id": "52fe421ac3a36847f8004591",
+                    "order": 4
                 },
                 {
-                "adult": False,
-                "backdrop_path": "/2u7zbn8EudG6kLlBzUYqP8RyFU4.jpg",
-                "genre_ids": [
-                    12,
-                    14,
-                    28
-                ],
-                "id": 122,
-                "original_language": "en",
-                "original_title": "The Lord of the Rings: The Return of the King",
-                "overview": "Aragorn is revealed as the heir to the ancient kings as he, Gandalf and the other members of the broken fellowship struggle to save Gondor from Sauron's forces. Meanwhile, Frodo and Sam take the ring closer to the heart of Mordor, the dark lord's realm.",
-                "popularity": 132.611,
-                "poster_path": "/rCzpDGLbOoPwLjy3OAm5NUPOTrC.jpg",
-                "release_date": "2003-12-01",
-                "title": "The Lord of the Rings: The Return of the King",
-                "video": False,
-                "vote_average": 8.5,
-                "vote_count": 23384,
-                "character": "Aragorn",
-                "credit_id": "52fe421bc3a36847f80046ff",
-                "order": 3
+                    "adult": False,
+                    "backdrop_path": "/2u7zbn8EudG6kLlBzUYqP8RyFU4.jpg",
+                    "genre_ids": [
+                        12,
+                        14,
+                        28
+                    ],
+                    "id": 122,
+                    "original_language": "en",
+                    "original_title": "The Lord of the Rings: The Return of the King",
+                    "overview": "Aragorn is revealed as the heir to the ancient kings as he, Gandalf and the other members of the broken fellowship struggle to save Gondor from Sauron's forces. Meanwhile, Frodo and Sam take the ring closer to the heart of Mordor, the dark lord's realm.",
+                    "popularity": 132.611,
+                    "poster_path": "/rCzpDGLbOoPwLjy3OAm5NUPOTrC.jpg",
+                    "release_date": "2003-12-01",
+                    "title": "The Lord of the Rings: The Return of the King",
+                    "video": False,
+                    "vote_average": 8.5,
+                    "vote_count": 23384,
+                    "character": "Aragorn",
+                    "credit_id": "52fe421bc3a36847f80046ff",
+                    "order": 3
                 },
                 {
-                "adult": False,
-                "backdrop_path": "/x2RS3uTcsJJ9IfjNPcgDmukoEcQ.jpg",
-                "genre_ids": [
-                    12,
-                    14,
-                    28
-                ],
-                "id": 120,
-                "original_language": "en",
-                "original_title": "The Lord of the Rings: The Fellowship of the Ring",
-                "overview": "Young hobbit Frodo Baggins, after inheriting a mysterious ring from his uncle Bilbo, must leave his home in order to keep it from falling into the hands of its evil creator. Along the way, a fellowship is formed to protect the ringbearer and make sure that the ring arrives at its final destination: Mt. Doom, the only place where it can be destroyed.",
-                "popularity": 164.708,
-                "poster_path": "/6oom5QYQ2yQTMJIbnvbkBL9cHo6.jpg",
-                "release_date": "2001-12-18",
-                "title": "The Lord of the Rings: The Fellowship of the Ring",
-                "video": False,
-                "vote_average": 8.4,
-                "vote_count": 24324,
-                "character": "Aragorn",
-                "credit_id": "52fe421ac3a36847f8004497",
-                "order": 2
+                    "adult": False,
+                    "backdrop_path": "/x2RS3uTcsJJ9IfjNPcgDmukoEcQ.jpg",
+                    "genre_ids": [
+                        12,
+                        14,
+                        28
+                    ],
+                    "id": 120,
+                    "original_language": "en",
+                    "original_title": "The Lord of the Rings: The Fellowship of the Ring",
+                    "overview": "Young hobbit Frodo Baggins, after inheriting a mysterious ring from his uncle Bilbo, must leave his home in order to keep it from falling into the hands of its evil creator. Along the way, a fellowship is formed to protect the ringbearer and make sure that the ring arrives at its final destination: Mt. Doom, the only place where it can be destroyed.",
+                    "popularity": 164.708,
+                    "poster_path": "/6oom5QYQ2yQTMJIbnvbkBL9cHo6.jpg",
+                    "release_date": "2001-12-18",
+                    "title": "The Lord of the Rings: The Fellowship of the Ring",
+                    "video": False,
+                    "vote_average": 8.4,
+                    "vote_count": 24324,
+                    "character": "Aragorn",
+                    "credit_id": "52fe421ac3a36847f8004497",
+                    "order": 2
                 },
                 {
-                "adult": False,
-                "backdrop_path": "/q3ND5eHCkwzbx7xL0inrSJko0PL.jpg",
-                "genre_ids": [
-                    80,
-                    53,
-                    18
-                ],
-                "id": 1965,
-                "original_language": "en",
-                "original_title": "A Perfect Murder",
-                "overview": "Millionaire industrialist Steven Taylor is a man who has everything but what he craves most: the love and fidelity of his wife. A hugely successful player in the New York financial world, he considers her to be his most treasured acquisition. But she needs more than simply the role of dazzling accessory.",
-                "popularity": 32.477,
-                "poster_path": "/wC0ax12N9GQ8vMXPEs4nES5AAiB.jpg",
-                "release_date": "1998-06-05",
-                "title": "A Perfect Murder",
-                "video": False,
-                "vote_average": 6.519,
-                "vote_count": 1311,
-                "character": "David Shaw",
-                "credit_id": "52fe4326c3a36847f803e3a5",
-                "order": 2
+                    "adult": False,
+                    "backdrop_path": "/q3ND5eHCkwzbx7xL0inrSJko0PL.jpg",
+                    "genre_ids": [
+                        80,
+                        53,
+                        18
+                    ],
+                    "id": 1965,
+                    "original_language": "en",
+                    "original_title": "A Perfect Murder",
+                    "overview": "Millionaire industrialist Steven Taylor is a man who has everything but what he craves most: the love and fidelity of his wife. A hugely successful player in the New York financial world, he considers her to be his most treasured acquisition. But she needs more than simply the role of dazzling accessory.",
+                    "popularity": 32.477,
+                    "poster_path": "/wC0ax12N9GQ8vMXPEs4nES5AAiB.jpg",
+                    "release_date": "1998-06-05",
+                    "title": "A Perfect Murder",
+                    "video": False,
+                    "vote_average": 6.519,
+                    "vote_count": 1311,
+                    "character": "David Shaw",
+                    "credit_id": "52fe4326c3a36847f803e3a5",
+                    "order": 2
                 }
             ]
-        }
-        )
+        })
         mock_requests.get("https://api.themoviedb.org/3/person/1328/movie_credits?language=en-US", json={
             "cast": [
                 {
-                "adult": False,
-                "backdrop_path": "/5EEdDTV0IBxJ2J4jDUDvl076v7f.jpg",
-                "genre_ids": [
-                    18,
-                    53,
-                    80
-                ],
-                "id": 59,
-                "original_language": "en",
-                "original_title": "A History of Violence",
-                "overview": "An average family is thrust into the spotlight after the father commits a seemingly self-defense murder at his diner.",
-                "popularity": 31.45,
-                "poster_path": "/3qnO72NHmUgs9JZXAmu4aId9QDl.jpg",
-                "release_date": "2005-09-23",
-                "title": "A History of Violence",
-                "video": False,
-                "vote_average": 7.168,
-                "vote_count": 3072,
-                "character": "Tom Stall / Joey Cusack",
-                "credit_id": "52fe4212c3a36847f8001927",
-                "order": 0
+                    "adult": False,
+                    "backdrop_path": "/5EEdDTV0IBxJ2J4jDUDvl076v7f.jpg",
+                    "genre_ids": [
+                        18,
+                        53,
+                        80
+                    ],
+                    "id": 59,
+                    "original_language": "en",
+                    "original_title": "A History of Violence",
+                    "overview": "An average family is thrust into the spotlight after the father commits a seemingly self-defense murder at his diner.",
+                    "popularity": 31.45,
+                    "poster_path": "/3qnO72NHmUgs9JZXAmu4aId9QDl.jpg",
+                    "release_date": "2005-09-23",
+                    "title": "A History of Violence",
+                    "video": False,
+                    "vote_average": 7.168,
+                    "vote_count": 3072,
+                    "character": "Tom Stall / Joey Cusack",
+                    "credit_id": "52fe4212c3a36847f8001927",
+                    "order": 0
                 },
                 {
-                "adult": False,
-                "backdrop_path": "/6G73mNyooWAEQTpckPSnFxFoNmc.jpg",
-                "genre_ids": [
-                    12,
-                    14,
-                    28
-                ],
-                "id": 121,
-                "original_language": "en",
-                "original_title": "The Lord of the Rings: The Two Towers",
-                "overview": "Frodo and Sam are trekking to Mordor to destroy the One Ring of Power while Gimli, Legolas and Aragorn search for the orc-captured Merry and Pippin. All along, nefarious wizard Saruman awaits the Fellowship members at the Orthanc Tower in Isengard.",
-                "popularity": 115.753,
-                "poster_path": "/5VTN0pR8gcqV3EPUHHfMGnJYN9L.jpg",
-                "release_date": "2002-12-18",
-                "title": "The Lord of the Rings: The Two Towers",
-                "video": False,
-                "vote_average": 8.4,
-                "vote_count": 21140,
-                "character": "Aragorn",
-                "credit_id": "52fe421ac3a36847f8004591",
-                "order": 4
+                    "adult": False,
+                    "backdrop_path": "/6G73mNyooWAEQTpckPSnFxFoNmc.jpg",
+                    "genre_ids": [
+                        12,
+                        14,
+                        28
+                    ],
+                    "id": 121,
+                    "original_language": "en",
+                    "original_title": "The Lord of the Rings: The Two Towers",
+                    "overview": "Frodo and Sam are trekking to Mordor to destroy the One Ring of Power while Gimli, Legolas and Aragorn search for the orc-captured Merry and Pippin. All along, nefarious wizard Saruman awaits the Fellowship members at the Orthanc Tower in Isengard.",
+                    "popularity": 115.753,
+                    "poster_path": "/5VTN0pR8gcqV3EPUHHfMGnJYN9L.jpg",
+                    "release_date": "2002-12-18",
+                    "title": "The Lord of the Rings: The Two Towers",
+                    "video": False,
+                    "vote_average": 8.4,
+                    "vote_count": 21140,
+                    "character": "Aragorn",
+                    "credit_id": "52fe421ac3a36847f8004591",
+                    "order": 4
                 },
                 {
-                "adult": False,
-                "backdrop_path": "/2u7zbn8EudG6kLlBzUYqP8RyFU4.jpg",
-                "genre_ids": [
-                    12,
-                    14,
-                    28
-                ],
-                "id": 122,
-                "original_language": "en",
-                "original_title": "The Lord of the Rings: The Return of the King",
-                "overview": "Aragorn is revealed as the heir to the ancient kings as he, Gandalf and the other members of the broken fellowship struggle to save Gondor from Sauron's forces. Meanwhile, Frodo and Sam take the ring closer to the heart of Mordor, the dark lord's realm.",
-                "popularity": 132.611,
-                "poster_path": "/rCzpDGLbOoPwLjy3OAm5NUPOTrC.jpg",
-                "release_date": "2003-12-01",
-                "title": "The Lord of the Rings: The Return of the King",
-                "video": False,
-                "vote_average": 8.5,
-                "vote_count": 23384,
-                "character": "Aragorn",
-                "credit_id": "52fe421bc3a36847f80046ff",
-                "order": 3
+                    "adult": False,
+                    "backdrop_path": "/2u7zbn8EudG6kLlBzUYqP8RyFU4.jpg",
+                    "genre_ids": [
+                        12,
+                        14,
+                        28
+                    ],
+                    "id": 122,
+                    "original_language": "en",
+                    "original_title": "The Lord of the Rings: The Return of the King",
+                    "overview": "Aragorn is revealed as the heir to the ancient kings as he, Gandalf and the other members of the broken fellowship struggle to save Gondor from Sauron's forces. Meanwhile, Frodo and Sam take the ring closer to the heart of Mordor, the dark lord's realm.",
+                    "popularity": 132.611,
+                    "poster_path": "/rCzpDGLbOoPwLjy3OAm5NUPOTrC.jpg",
+                    "release_date": "2003-12-01",
+                    "title": "The Lord of the Rings: The Return of the King",
+                    "video": False,
+                    "vote_average": 8.5,
+                    "vote_count": 23384,
+                    "character": "Aragorn",
+                    "credit_id": "52fe421bc3a36847f80046ff",
+                    "order": 3
                 },
                 {
-                "adult": False,
-                "backdrop_path": "/x2RS3uTcsJJ9IfjNPcgDmukoEcQ.jpg",
-                "genre_ids": [
-                    12,
-                    14,
-                    28
-                ],
-                "id": 120,
-                "original_language": "en",
-                "original_title": "The Lord of the Rings: The Fellowship of the Ring",
-                "overview": "Young hobbit Frodo Baggins, after inheriting a mysterious ring from his uncle Bilbo, must leave his home in order to keep it from falling into the hands of its evil creator. Along the way, a fellowship is formed to protect the ringbearer and make sure that the ring arrives at its final destination: Mt. Doom, the only place where it can be destroyed.",
-                "popularity": 164.708,
-                "poster_path": "/6oom5QYQ2yQTMJIbnvbkBL9cHo6.jpg",
-                "release_date": "2001-12-18",
-                "title": "The Lord of the Rings: The Fellowship of the Ring",
-                "video": False,
-                "vote_average": 8.4,
-                "vote_count": 24324,
-                "character": "Aragorn",
-                "credit_id": "52fe421ac3a36847f8004497",
-                "order": 2
+                    "adult": False,
+                    "backdrop_path": "/x2RS3uTcsJJ9IfjNPcgDmukoEcQ.jpg",
+                    "genre_ids": [
+                        12,
+                        14,
+                        28
+                    ],
+                    "id": 120,
+                    "original_language": "en",
+                    "original_title": "The Lord of the Rings: The Fellowship of the Ring",
+                    "overview": "Young hobbit Frodo Baggins, after inheriting a mysterious ring from his uncle Bilbo, must leave his home in order to keep it from falling into the hands of its evil creator. Along the way, a fellowship is formed to protect the ringbearer and make sure that the ring arrives at its final destination: Mt. Doom, the only place where it can be destroyed.",
+                    "popularity": 164.708,
+                    "poster_path": "/6oom5QYQ2yQTMJIbnvbkBL9cHo6.jpg",
+                    "release_date": "2001-12-18",
+                    "title": "The Lord of the Rings: The Fellowship of the Ring",
+                    "video": False,
+                    "vote_average": 8.4,
+                    "vote_count": 24324,
+                    "character": "Aragorn",
+                    "credit_id": "52fe421ac3a36847f8004497",
+                    "order": 2
                 },
                 {
-                "adult": False,
-                "backdrop_path": "/q3ND5eHCkwzbx7xL0inrSJko0PL.jpg",
-                "genre_ids": [
-                    80,
-                    53,
-                    18
-                ],
-                "id": 1965,
-                "original_language": "en",
-                "original_title": "A Perfect Murder",
-                "overview": "Millionaire industrialist Steven Taylor is a man who has everything but what he craves most: the love and fidelity of his wife. A hugely successful player in the New York financial world, he considers her to be his most treasured acquisition. But she needs more than simply the role of dazzling accessory.",
-                "popularity": 32.477,
-                "poster_path": "/wC0ax12N9GQ8vMXPEs4nES5AAiB.jpg",
-                "release_date": "1998-06-05",
-                "title": "A Perfect Murder",
-                "video": False,
-                "vote_average": 6.519,
-                "vote_count": 1311,
-                "character": "David Shaw",
-                "credit_id": "52fe4326c3a36847f803e3a5",
-                "order": 2
+                    "adult": False,
+                    "backdrop_path": "/q3ND5eHCkwzbx7xL0inrSJko0PL.jpg",
+                    "genre_ids": [
+                        80,
+                        53,
+                        18
+                    ],
+                    "id": 1965,
+                    "original_language": "en",
+                    "original_title": "A Perfect Murder",
+                    "overview": "Millionaire industrialist Steven Taylor is a man who has everything but what he craves most: the love and fidelity of his wife. A hugely successful player in the New York financial world, he considers her to be his most treasured acquisition. But she needs more than simply the role of dazzling accessory.",
+                    "popularity": 32.477,
+                    "poster_path": "/wC0ax12N9GQ8vMXPEs4nES5AAiB.jpg",
+                    "release_date": "1998-06-05",
+                    "title": "A Perfect Murder",
+                    "video": False,
+                    "vote_average": 6.519,
+                    "vote_count": 1311,
+                    "character": "David Shaw",
+                    "credit_id": "52fe4326c3a36847f803e3a5",
+                    "order": 2
                 }
             ]
-        }
-        )
+        })
         mock_requests.get("https://api.themoviedb.org/3/person/110/movie_credits?language=en-US", json={
             "cast": [
                 {
-                "adult": False,
-                "backdrop_path": "/5EEdDTV0IBxJ2J4jDUDvl076v7f.jpg",
-                "genre_ids": [
-                    18,
-                    53,
-                    80
-                ],
-                "id": 59,
-                "original_language": "en",
-                "original_title": "A History of Violence",
-                "overview": "An average family is thrust into the spotlight after the father commits a seemingly self-defense murder at his diner.",
-                "popularity": 31.45,
-                "poster_path": "/3qnO72NHmUgs9JZXAmu4aId9QDl.jpg",
-                "release_date": "2005-09-23",
-                "title": "A History of Violence",
-                "video": False,
-                "vote_average": 7.168,
-                "vote_count": 3072,
-                "character": "Tom Stall / Joey Cusack",
-                "credit_id": "52fe4212c3a36847f8001927",
-                "order": 0
+                    "adult": False,
+                    "backdrop_path": "/5EEdDTV0IBxJ2J4jDUDvl076v7f.jpg",
+                    "genre_ids": [
+                        18,
+                        53,
+                        80
+                    ],
+                    "id": 59,
+                    "original_language": "en",
+                    "original_title": "A History of Violence",
+                    "overview": "An average family is thrust into the spotlight after the father commits a seemingly self-defense murder at his diner.",
+                    "popularity": 31.45,
+                    "poster_path": "/3qnO72NHmUgs9JZXAmu4aId9QDl.jpg",
+                    "release_date": "2005-09-23",
+                    "title": "A History of Violence",
+                    "video": False,
+                    "vote_average": 7.168,
+                    "vote_count": 3072,
+                    "character": "Tom Stall / Joey Cusack",
+                    "credit_id": "52fe4212c3a36847f8001927",
+                    "order": 0
                 },
                 {
-                "adult": False,
-                "backdrop_path": "/6G73mNyooWAEQTpckPSnFxFoNmc.jpg",
-                "genre_ids": [
-                    12,
-                    14,
-                    28
-                ],
-                "id": 121,
-                "original_language": "en",
-                "original_title": "The Lord of the Rings: The Two Towers",
-                "overview": "Frodo and Sam are trekking to Mordor to destroy the One Ring of Power while Gimli, Legolas and Aragorn search for the orc-captured Merry and Pippin. All along, nefarious wizard Saruman awaits the Fellowship members at the Orthanc Tower in Isengard.",
-                "popularity": 115.753,
-                "poster_path": "/5VTN0pR8gcqV3EPUHHfMGnJYN9L.jpg",
-                "release_date": "2002-12-18",
-                "title": "The Lord of the Rings: The Two Towers",
-                "video": False,
-                "vote_average": 8.4,
-                "vote_count": 21140,
-                "character": "Aragorn",
-                "credit_id": "52fe421ac3a36847f8004591",
-                "order": 4
+                    "adult": False,
+                    "backdrop_path": "/6G73mNyooWAEQTpckPSnFxFoNmc.jpg",
+                    "genre_ids": [
+                        12,
+                        14,
+                        28
+                    ],
+                    "id": 121,
+                    "original_language": "en",
+                    "original_title": "The Lord of the Rings: The Two Towers",
+                    "overview": "Frodo and Sam are trekking to Mordor to destroy the One Ring of Power while Gimli, Legolas and Aragorn search for the orc-captured Merry and Pippin. All along, nefarious wizard Saruman awaits the Fellowship members at the Orthanc Tower in Isengard.",
+                    "popularity": 115.753,
+                    "poster_path": "/5VTN0pR8gcqV3EPUHHfMGnJYN9L.jpg",
+                    "release_date": "2002-12-18",
+                    "title": "The Lord of the Rings: The Two Towers",
+                    "video": False,
+                    "vote_average": 8.4,
+                    "vote_count": 21140,
+                    "character": "Aragorn",
+                    "credit_id": "52fe421ac3a36847f8004591",
+                    "order": 4
                 },
                 {
-                "adult": False,
-                "backdrop_path": "/2u7zbn8EudG6kLlBzUYqP8RyFU4.jpg",
-                "genre_ids": [
-                    12,
-                    14,
-                    28
-                ],
-                "id": 122,
-                "original_language": "en",
-                "original_title": "The Lord of the Rings: The Return of the King",
-                "overview": "Aragorn is revealed as the heir to the ancient kings as he, Gandalf and the other members of the broken fellowship struggle to save Gondor from Sauron's forces. Meanwhile, Frodo and Sam take the ring closer to the heart of Mordor, the dark lord's realm.",
-                "popularity": 132.611,
-                "poster_path": "/rCzpDGLbOoPwLjy3OAm5NUPOTrC.jpg",
-                "release_date": "2003-12-01",
-                "title": "The Lord of the Rings: The Return of the King",
-                "video": False,
-                "vote_average": 8.5,
-                "vote_count": 23384,
-                "character": "Aragorn",
-                "credit_id": "52fe421bc3a36847f80046ff",
-                "order": 3
+                    "adult": False,
+                    "backdrop_path": "/2u7zbn8EudG6kLlBzUYqP8RyFU4.jpg",
+                    "genre_ids": [
+                        12,
+                        14,
+                        28
+                    ],
+                    "id": 122,
+                    "original_language": "en",
+                    "original_title": "The Lord of the Rings: The Return of the King",
+                    "overview": "Aragorn is revealed as the heir to the ancient kings as he, Gandalf and the other members of the broken fellowship struggle to save Gondor from Sauron's forces. Meanwhile, Frodo and Sam take the ring closer to the heart of Mordor, the dark lord's realm.",
+                    "popularity": 132.611,
+                    "poster_path": "/rCzpDGLbOoPwLjy3OAm5NUPOTrC.jpg",
+                    "release_date": "2003-12-01",
+                    "title": "The Lord of the Rings: The Return of the King",
+                    "video": False,
+                    "vote_average": 8.5,
+                    "vote_count": 23384,
+                    "character": "Aragorn",
+                    "credit_id": "52fe421bc3a36847f80046ff",
+                    "order": 3
                 },
                 {
-                "adult": False,
-                "backdrop_path": "/x2RS3uTcsJJ9IfjNPcgDmukoEcQ.jpg",
-                "genre_ids": [
-                    12,
-                    14,
-                    28
-                ],
-                "id": 120,
-                "original_language": "en",
-                "original_title": "The Lord of the Rings: The Fellowship of the Ring",
-                "overview": "Young hobbit Frodo Baggins, after inheriting a mysterious ring from his uncle Bilbo, must leave his home in order to keep it from falling into the hands of its evil creator. Along the way, a fellowship is formed to protect the ringbearer and make sure that the ring arrives at its final destination: Mt. Doom, the only place where it can be destroyed.",
-                "popularity": 164.708,
-                "poster_path": "/6oom5QYQ2yQTMJIbnvbkBL9cHo6.jpg",
-                "release_date": "2001-12-18",
-                "title": "The Lord of the Rings: The Fellowship of the Ring",
-                "video": False,
-                "vote_average": 8.4,
-                "vote_count": 24324,
-                "character": "Aragorn",
-                "credit_id": "52fe421ac3a36847f8004497",
-                "order": 2
+                    "adult": False,
+                    "backdrop_path": "/x2RS3uTcsJJ9IfjNPcgDmukoEcQ.jpg",
+                    "genre_ids": [
+                        12,
+                        14,
+                        28
+                    ],
+                    "id": 120,
+                    "original_language": "en",
+                    "original_title": "The Lord of the Rings: The Fellowship of the Ring",
+                    "overview": "Young hobbit Frodo Baggins, after inheriting a mysterious ring from his uncle Bilbo, must leave his home in order to keep it from falling into the hands of its evil creator. Along the way, a fellowship is formed to protect the ringbearer and make sure that the ring arrives at its final destination: Mt. Doom, the only place where it can be destroyed.",
+                    "popularity": 164.708,
+                    "poster_path": "/6oom5QYQ2yQTMJIbnvbkBL9cHo6.jpg",
+                    "release_date": "2001-12-18",
+                    "title": "The Lord of the Rings: The Fellowship of the Ring",
+                    "video": False,
+                    "vote_average": 8.4,
+                    "vote_count": 24324,
+                    "character": "Aragorn",
+                    "credit_id": "52fe421ac3a36847f8004497",
+                    "order": 2
                 },
                 {
-                "adult": False,
-                "backdrop_path": "/q3ND5eHCkwzbx7xL0inrSJko0PL.jpg",
-                "genre_ids": [
-                    80,
-                    53,
-                    18
-                ],
-                "id": 1965,
-                "original_language": "en",
-                "original_title": "A Perfect Murder",
-                "overview": "Millionaire industrialist Steven Taylor is a man who has everything but what he craves most: the love and fidelity of his wife. A hugely successful player in the New York financial world, he considers her to be his most treasured acquisition. But she needs more than simply the role of dazzling accessory.",
-                "popularity": 32.477,
-                "poster_path": "/wC0ax12N9GQ8vMXPEs4nES5AAiB.jpg",
-                "release_date": "1998-06-05",
-                "title": "A Perfect Murder",
-                "video": False,
-                "vote_average": 6.519,
-                "vote_count": 1311,
-                "character": "David Shaw",
-                "credit_id": "52fe4326c3a36847f803e3a5",
-                "order": 2
+                    "adult": False,
+                    "backdrop_path": "/q3ND5eHCkwzbx7xL0inrSJko0PL.jpg",
+                    "genre_ids": [
+                        80,
+                        53,
+                        18
+                    ],
+                    "id": 1965,
+                    "original_language": "en",
+                    "original_title": "A Perfect Murder",
+                    "overview": "Millionaire industrialist Steven Taylor is a man who has everything but what he craves most: the love and fidelity of his wife. A hugely successful player in the New York financial world, he considers her to be his most treasured acquisition. But she needs more than simply the role of dazzling accessory.",
+                    "popularity": 32.477,
+                    "poster_path": "/wC0ax12N9GQ8vMXPEs4nES5AAiB.jpg",
+                    "release_date": "1998-06-05",
+                    "title": "A Perfect Murder",
+                    "video": False,
+                    "vote_average": 6.519,
+                    "vote_count": 1311,
+                    "character": "David Shaw",
+                    "credit_id": "52fe4326c3a36847f803e3a5",
+                    "order": 2
                 }
             ]
         }
         )
-    
-            
-        input = {'movies': [{'id': 238, 'title': 'The Lord of the Rings: The Return of the King', 'actors': [110, 109, 1328, 1327], 'actor_images': ['/jPsLqiYGSofU4s6BjrxnefMfabb.jpg', '/9RgzFqbmWBLVfq9wvyDo5UW8VT1.jpg']}]}
+
+        data = {'movies': [{'id': 238, 'title': 'The Lord of the Rings: The Return of the King', 'actors': [110, 109, 1328, 1327], 'actor_images': ['/jPsLqiYGSofU4s6BjrxnefMfabb.jpg', '/9RgzFqbmWBLVfq9wvyDo5UW8VT1.jpg']}]}
         expected = {'movies': [{'id': 238, 'title': 'The Lord of the Rings: The Return of the King', 'actors': [110, 109, 1328, 1327], 'actor_images': ['/jPsLqiYGSofU4s6BjrxnefMfabb.jpg', '/9RgzFqbmWBLVfq9wvyDo5UW8VT1.jpg'], 'alternative_answers': {'The Lord of the Rings: The Two Towers', 'The Lord of the Rings: The Return of the King', 'The Lord of the Rings: The Fellowship of the Ring'}}]}
 
-        actual = src.movies.related_movies(input, headers)
-        assert actual == expected
+        src.movies.related_movies(data, headers)
+        assert data == expected


### PR DESCRIPTION
# #20 -> #23 changes/feedback
- URL formatting changes:
    - `TMDB_BASE_URL`: remove trailing slash
- Clean up method header + comments
    - `This function ...` (we already know it's a function)
    - `:param movies: dict - a dict of movie data` (using the word in the definition)
    - `:return: dict - return the api response` (same thing)
    - Lots of run-on sentences
    - `and then calls the popular_actors function` (typically method headers are for giving a higher-level description, some summary of information we can't directly see or isn't easy to figure out from reading the code directly. A reader can simply scroll down and see that we're calling the `popular_actors` function, so we can leave that out unless the action of calling that function is significant enough to note)
    - `This is a helper function` (same thing)
    - `:param cast: dict - the cast` (same thing, we choose variable names specifically so it tells us what content its storing, build on that mental context when describing further)
- Add `TMDB_POPULAR_URI`, `TMDB_TOP_RATED_URI`, `TMDB_MOVIES_ACTORS_URI_FMT` (and move trailing slash here)
- Build `params` as dict to increase readability
- Add `CONTENT_LANGUAGE`, `TMDB_REGION_CODE_USA`, `TMDB_GENRE_ANIMATION` constants to reduce hardcoding
- Change `extract_movie_data` list comprehension to full loop for readability
- Pass-by-value vs pass-by-reference:
    - `actors` receives a dict/list (which is a reference), modifies it, and then returns the same pointer.
- `actor_url` -> `actor_urls` (plural should be used to hint to the reader that it's a list/dict/contains multiple items)
- Fix indentation in data blobs
- `input` is a reserved keyword/existing function in Python, so we need to be careful with naming a variable that way.